### PR TITLE
Decouple the seeds used to the different parts of the pipeline

### DIFF
--- a/examples/desi_y5.ini
+++ b/examples/desi_y5.ini
@@ -29,6 +29,13 @@ analysis_dir = /global/cfs/cdirs/desicollab/science/lya/picca_on_mocks/london/v9
 # Mock code options: ["lyacolore", "saclay", "ohio"]
 mock_code = lyacolore
 mock_version = v9.0
+
+# Used if seed of transmission boxes is different from seed of QQ runs
+; input_seeds = 0-5
+
+# Used if seed of QSO catalog is different from seed of QQ runs
+; cat_seeds = 0-5
+
 qq_seeds = 0-5
 qq_run_type = desi-4.0-4
 

--- a/examples/run_vega_fitter.ini
+++ b/examples/run_vega_fitter.ini
@@ -1,6 +1,8 @@
 [mock_setup]
 analysis_dir = /global/cfs/cdirs/desicollab/science/lya/picca_on_mocks/london/v9.0/
 mock_version = v9.0.0.0i
+input_seeds = 0-5
+cat_seeds = 0-5
 qq_seeds = 0-5
 qq_run_type = desi-4.124-4-prod
 ; analysis_name = baseline

--- a/examples/run_vega_fitter.ini
+++ b/examples/run_vega_fitter.ini
@@ -1,0 +1,31 @@
+[mock_setup]
+analysis_dir = /global/cfs/cdirs/desicollab/science/lya/picca_on_mocks/london/v9.0/
+mock_version = v9.0.0.0i
+qq_seeds = 0-5
+qq_run_type = desi-4.124-4-prod
+; analysis_name = baseline
+
+output_dir = path/to/output/dir
+run_flag = False
+
+[correlations]
+dist_path = path/to/distortion/directory
+rmin = 10
+rmax = 180
+fast_metals = True
+
+[builder]
+bias_beta_config.LYA = bias_beta
+bias_beta_config.QSO = bias_bias_eta
+PolyChord.num_live = 192
+priors.beta_hcd = gaussian 0.5 0.09
+
+[fit_info]
+fit_type = lyaxlya_lyaxlyb_lyaxqso_lybxqso
+name_extension = test
+sample_params = ap at bias_LYA beta_LYA bias_QSO sigma_velo_disp_gauss_QSO drp_QSO bias_hcd beta_hcd bias_eta_SiII(1190) bias_eta_SiII(1193) bias_eta_SiIII(1207) bias_eta_SiII(1260)
+
+match_params = path/to/match/params/file
+
+[parameters]
+L0_hcd = 6.5

--- a/examples/run_vega_fitter.ini
+++ b/examples/run_vega_fitter.ini
@@ -10,9 +10,11 @@ qq_run_type = desi-4.124-4-prod
 output_dir = path/to/output/dir
 run_flag = False
 inverted_cat_seed = True
+cat_path = /global/cfs/cdirs/desicollab/mocks/lya_forest/develop/london/qq_desi/v9.0_Y1/
 
 [correlations]
 dist_path = path/to/distortion/directory
+cat_path = path/to/catalogue/directory
 rmin = 10
 rmax = 180
 fast_metals = True
@@ -28,6 +30,8 @@ fit_type = lyaxlya_lyaxlyb_lyaxqso_lybxqso
 name_extension = test
 sample_params = ap at bias_LYA beta_LYA bias_QSO sigma_velo_disp_gauss_QSO drp_QSO bias_hcd beta_hcd bias_eta_SiII(1190) bias_eta_SiII(1193) bias_eta_SiIII(1207) bias_eta_SiII(1260)
 
+use_full_cov = True
+# global_cov_file = path/to/global/covariance/file
 match_params = path/to/match/params/file
 
 [parameters]

--- a/examples/run_vega_fitter.ini
+++ b/examples/run_vega_fitter.ini
@@ -9,6 +9,7 @@ qq_run_type = desi-4.124-4-prod
 
 output_dir = path/to/output/dir
 run_flag = False
+inverted_cat_seed = True
 
 [correlations]
 dist_path = path/to/distortion/directory

--- a/lyatools/defaults/desi_y5.ini
+++ b/lyatools/defaults/desi_y5.ini
@@ -29,6 +29,13 @@ analysis_dir = /global/cfs/cdirs/desicollab/science/lya/picca_on_mocks/london/v9
 # Mock code options: ["lyacolore", "saclay", "ohio"]
 mock_code = lyacolore
 mock_version = v9.0
+
+# Used if seed of transmission boxes is different from seed of QQ runs
+; input_seeds = 0-5
+
+# Used if seed of QSO catalog is different from seed of QQ runs
+; cat_seeds = 0-5
+
 qq_seeds = 0-5
 qq_run_type = desi-4.0-4
 

--- a/lyatools/dir_handlers.py
+++ b/lyatools/dir_handlers.py
@@ -121,36 +121,3 @@ class AnalysisDir:
 
         self.scripts_dir = self.analysis_dir / 'scripts'
         check_dir(self.scripts_dir)
-
-
-# @dataclass
-# class CorrDir:
-#     """
-#     An object that contains the directory structure for an individual correlation.
-#     """
-#     main_path: str
-#     corr_dirname: str = 'correlations'
-#     results_dirname: str = 'measurements'
-#     run_dirname: str = 'run_files'
-#     scripts_dirname: str = 'scripts'
-
-#     corr_dir: Path = field(init=False)
-#     results_dir: Path = field(init=False)
-#     run_dir: Path = field(init=False)
-#     scripts_dir: Path = field(init=False)
-
-#     def __post_init__(self):
-#         main_path = Path(self.main_path)
-#         check_dir(main_path)
-
-#         self.corr_dir = main_path / self.corr_dirname
-#         check_dir(self.corr_dir)
-
-#         self.results_dir = self.corr_dir / self.results_dirname
-#         check_dir(self.results_dir)
-
-#         self.run_dir = self.corr_dir / self.run_dirname
-#         check_dir(self.run_dir)
-
-#         self.scripts_dir = self.corr_dir / self.scripts_dirname
-#         check_dir(self.scripts_dir)

--- a/lyatools/export.py
+++ b/lyatools/export.py
@@ -25,8 +25,11 @@ def find_dmat(dmat_path, corr_type):
     return dmat_dir / name_list[0]
 
 
-def make_export_runs(seed, analysis_struct, corr_paths, job, add_dmat=False, dmat_path=None,
-                     shuffled=False, corr_job_ids=None):
+def make_export_runs(seed, analysis_struct, corr_paths, job, config, corr_job_ids=None):
+    add_dmat = config.getboolean('add_dmat')
+    dmat_path = config.get('dmat_path')
+    shuffled = config.getboolean('subtract_shuffled')
+
     corr_dict = {}
     export_commands = []
     for cf_path in corr_paths:
@@ -62,6 +65,10 @@ def make_export_runs(seed, analysis_struct, corr_paths, job, add_dmat=False, dma
 
             if shuffled_path is not None:
                 command += f'--remove-shuffled-correlation {shuffled_path} '
+
+            if config.get(f'corr-mat-{corr_type}') is not None:
+                corr_mat = config.get(f'corr-mat-{corr_type}')
+                command += f'--cor {corr_mat} '
 
             export_commands += [command]
 

--- a/lyatools/export.py
+++ b/lyatools/export.py
@@ -272,22 +272,25 @@ def mpi_export(export_dict, job, analysis_struct, corr_job_ids=None):
 
     cov_job_id = None
     if len(individual_cov_commands) > 1:
+        ntasks_per_node = min(len(individual_cov_commands), 32)
         cov_job_id = mpi_export_covariances(
             individual_cov_commands, job, analysis_struct, script_name='individual_cov',
-            num_nodes=1, ntasks_per_node=32, corr_job_ids=corr_job_ids)
+            num_nodes=1, ntasks_per_node=ntasks_per_node, corr_job_ids=corr_job_ids)
 
     if cov_job_id is None:
         cov_job_id = corr_job_ids
     if len(smooth_cov_commands) > 1:
         num_nodes = max(len(smooth_cov_commands) // 32, 1)
+        ntasks_per_node = min(len(smooth_cov_commands), 32)
         _ = mpi_export_covariances(
             smooth_cov_commands, job, analysis_struct, script_name='smooth_cov',
-            num_nodes=num_nodes, ntasks_per_node=32, corr_job_ids=cov_job_id)
+            num_nodes=num_nodes, ntasks_per_node=ntasks_per_node, corr_job_ids=cov_job_id)
 
     if len(stacked_cov_commands) > 1:
+        ntasks_per_node = min(len(stacked_cov_commands), 32)
         _ = mpi_export_covariances(
             stacked_cov_commands, job, analysis_struct, script_name='stacked_cov',
-            num_nodes=1, ntasks_per_node=32, corr_job_ids=corr_job_ids)
+            num_nodes=1, ntasks_per_node=ntasks_per_node, corr_job_ids=corr_job_ids)
 
 
 def mpi_export_correlations(export_commands, job, analysis_struct, corr_job_ids=None):

--- a/lyatools/export.py
+++ b/lyatools/export.py
@@ -258,17 +258,17 @@ def mpi_export(export_dict, job, analysis_struct, corr_job_ids=None):
     individual_cov_commands = []
     for cov_commands in export_cov_commands:
         if len(cov_commands) >= 1:
-            individual_cov_commands += cov_commands[0]
+            individual_cov_commands += [cov_commands[0]]
 
     smooth_cov_commands = []
     for cov_commands in export_cov_commands:
         if len(cov_commands) >= 2:
-            smooth_cov_commands += cov_commands[1]
+            smooth_cov_commands += [cov_commands[1]]
 
     stacked_cov_commands = []
     for cov_commands in export_cov_commands:
         if len(cov_commands) >= 3:
-            stacked_cov_commands += cov_commands[2]
+            stacked_cov_commands += [cov_commands[2]]
 
     if len(individual_cov_commands) > 1:
         mpi_export_covariances(

--- a/lyatools/export.py
+++ b/lyatools/export.py
@@ -123,7 +123,7 @@ def export_full_cov(seed, analysis_struct, corr_paths, job, corr_job_ids=None):
     command = ''
     if not output_path.is_file():
         command += '/global/homes/a/acuceu/desi_acuceu/notebooks_perl'
-        command += '/mocks/covariance/export_individual_cov.py '
+        command += '/mocks/covariance/export_full_cov.py '
         command += '-i /global/cfs/projectdirs/desi/users/acuceu/notebooks_perl'
         command += '/mocks/covariance/output/cov-mat-colore-160-mocks-smooth-fixed.fits '
         command += f'-c {cf_paths_str} -o {output_path}\n\n'
@@ -137,7 +137,7 @@ def export_full_cov(seed, analysis_struct, corr_paths, job, corr_job_ids=None):
         return None
 
     # Make the header
-    header = submit_utils.make_header(job.get('nersc_machine'), time=0.75,
+    header = submit_utils.make_header(job.get('nersc_machine'), time=0.2,
                                       omp_threads=64, job_name=f'export-cov_{seed}',
                                       err_file=analysis_struct.logs_dir/f'export-cov-{seed}-%j.err',
                                       out_file=analysis_struct.logs_dir/f'export-cov-{seed}-%j.out')

--- a/lyatools/export.py
+++ b/lyatools/export.py
@@ -290,7 +290,7 @@ def mpi_export(export_dict, job, analysis_struct, corr_job_ids=None):
 def mpi_export_correlations(export_commands, job, analysis_struct, corr_job_ids=None):
     # Make the header
     header = submit_utils.make_header(job.get('nersc_machine'), time=1.0,
-                                      omp_threads=64, job_name='stack_export',
+                                      omp_threads=2, job_name='stack_export',
                                       err_file=analysis_struct.logs_dir/'mpi_export-%j.err',
                                       out_file=analysis_struct.logs_dir/'mpi_export-%j.out')
 
@@ -317,7 +317,7 @@ def mpi_export_covariances(
     # Make the header
     header = submit_utils.make_header(
         job.get('nersc_machine'), time=job.get('mpi-export-time', 4.0), nodes=int(num_nodes),
-        omp_threads=64, job_name=script_name,
+        omp_threads=2, job_name=script_name,
         err_file=analysis_struct.logs_dir/'mpi_export-cov-%j.err',
         out_file=analysis_struct.logs_dir/'mpi_export-cov-%j.out')
 

--- a/lyatools/export.py
+++ b/lyatools/export.py
@@ -244,7 +244,6 @@ def stack_correlations(corr_dict, global_struct, job, add_dmat=False, dmat_path=
 
 
 def mpi_export(export_dict, job, analysis_struct, corr_job_ids=None):
-    print(corr_job_ids)
     export_commands = export_dict['export_commands']
     export_cov_commands = export_dict['export_cov_commands']
 

--- a/lyatools/export.py
+++ b/lyatools/export.py
@@ -244,6 +244,7 @@ def stack_correlations(corr_dict, global_struct, job, add_dmat=False, dmat_path=
 
 
 def mpi_export(export_dict, job, analysis_struct, corr_job_ids=None):
+    print(corr_job_ids)
     export_commands = export_dict['export_commands']
     export_cov_commands = export_dict['export_cov_commands']
 

--- a/lyatools/export.py
+++ b/lyatools/export.py
@@ -116,8 +116,8 @@ def export_full_cov(seed, analysis_struct, corr_paths, job, corr_job_ids=None):
             if corr_type in cf_path.name:
                 ordered_cf_paths[i] = cf_path
 
-    output_path = corr_paths[0].parent / 'full_cov.fits.gz'
-    output_path_smoothed = corr_paths[0].parent / 'full_cov_smooth.fits.gz'
+    output_path = corr_paths[0].parent / 'full_cov.fits'
+    output_path_smoothed = corr_paths[0].parent / 'full_cov_smooth.fits'
     cf_paths_str = ' '.join([str(cf_path) for cf_path in ordered_cf_paths])
     command = '/global/homes/a/acuceu/desi_acuceu/notebooks_perl'
     command += f'/mocks/covariance/export_individual_cov.py -i {cf_paths_str} -o {output_path}\n\n'

--- a/lyatools/export.py
+++ b/lyatools/export.py
@@ -79,7 +79,7 @@ def make_export_runs(seed, analysis_struct, corr_paths, job, config, corr_job_id
 
     if len(export_commands) < 1:
         print(f'No individual mock export needed for seed {seed}.')
-        return corr_dict, None
+        return corr_dict, None, None
 
     # Make the header
     header = submit_utils.make_header(job.get('nersc_machine'), time=0.2,
@@ -245,6 +245,10 @@ def stack_correlations(corr_dict, global_struct, job, add_dmat=False, dmat_path=
 def mpi_export(export_dict, job, analysis_struct, corr_job_ids=None):
     export_commands = export_dict['export_commands']
     export_cov_commands = export_dict['export_cov_commands']
+
+    # Filter Nones
+    export_commands = [command for command in export_commands if command is not None]
+    export_cov_commands = [command for command in export_cov_commands if command is not None]
 
     if len(export_commands) > 1:
         mpi_export_correlations(export_commands, job, analysis_struct, corr_job_ids=corr_job_ids)

--- a/lyatools/export.py
+++ b/lyatools/export.py
@@ -134,7 +134,7 @@ def export_full_cov(seed, analysis_struct, corr_paths, job, corr_job_ids=None):
         return None
 
     # Make the header
-    header = submit_utils.make_header(job.get('nersc_machine'), time=0.2,
+    header = submit_utils.make_header(job.get('nersc_machine'), time=0.75,
                                       omp_threads=64, job_name=f'export-cov_{seed}',
                                       err_file=analysis_struct.logs_dir/f'export-cov-{seed}-%j.err',
                                       out_file=analysis_struct.logs_dir/f'export-cov-{seed}-%j.out')

--- a/lyatools/export.py
+++ b/lyatools/export.py
@@ -116,18 +116,21 @@ def export_full_cov(seed, analysis_struct, corr_paths, job, corr_job_ids=None):
             if corr_type in cf_path.name:
                 ordered_cf_paths[i] = cf_path
 
-    output_path = corr_paths[0].parent / 'full_cov.fits'
-    output_path_smoothed = corr_paths[0].parent / 'full_cov_smooth.fits'
+    output_path = corr_paths[0].parent / 'full_cov_global.fits'
+    # output_path_smoothed = corr_paths[0].parent / 'full_cov_smooth.fits'
     cf_paths_str = ' '.join([str(cf_path) for cf_path in ordered_cf_paths])
 
     command = ''
     if not output_path.is_file():
         command += '/global/homes/a/acuceu/desi_acuceu/notebooks_perl'
-        command += f'/mocks/covariance/export_individual_cov.py -i {cf_paths_str} -o {output_path}\n\n'
+        command += '/mocks/covariance/export_individual_cov.py '
+        command += '-i /global/cfs/projectdirs/desi/users/acuceu/notebooks_perl'
+        command += '/mocks/covariance/output/cov-mat-colore-160-mocks-smooth-fixed.fits '
+        command += f'-c {cf_paths_str} -o {output_path}\n\n'
 
-    if not output_path_smoothed.is_file():
-        command += '/global/homes/a/acuceu/desi_acuceu/notebooks_perl/mocks/covariance/smoothit.py '
-        command += f'-i {output_path} -o {output_path_smoothed} '
+    # if not output_path_smoothed.is_file():
+    #     command += '/global/homes/a/acuceu/desi_acuceu/notebooks_perl/mocks/covariance/smoothit.py '
+    #     command += f'-i {output_path} -o {output_path_smoothed} '
 
     if command == '':
         print(f'Full covariance already exists for seed {seed}.')

--- a/lyatools/export.py
+++ b/lyatools/export.py
@@ -33,7 +33,12 @@ def make_export_runs(seed, analysis_struct, corr_paths, job, config, corr_job_id
     corr_dict = {}
     export_commands = []
     for cf_path in corr_paths:
-        exp_file = submit_utils.append_string_to_correlation_path(cf_path, '-exp')
+        exp_string = config.get('exp_string')
+
+        if exp_string is not None:
+            exp_file = submit_utils.append_string_to_correlation_path(cf_path, f'_{exp_string}-exp')
+        else:
+            exp_file = submit_utils.append_string_to_correlation_path(cf_path, '-exp')
 
         shuffled_path = None
         if shuffled:

--- a/lyatools/export.py
+++ b/lyatools/export.py
@@ -324,7 +324,9 @@ def mpi_export_covariances(
     env_command = job.get('env_command')
     text += f'{env_command}\n\n'
 
-    text += f'srun --ntasks-per-node={ntasks_per_node} lyatools-mpi-export -i {commands} '
+    text_commands = '"' + '" "'.join(commands) + '"'
+
+    text += f'srun --ntasks-per-node={ntasks_per_node} lyatools-mpi-export -i {text_commands} '
     text += f'-l {analysis_struct.logs_dir}\n'
 
     # Write the script.

--- a/lyatools/quickquasars.py
+++ b/lyatools/quickquasars.py
@@ -2,7 +2,8 @@ from . import dir_handlers, submit_utils
 from lyatools.qq_run_args import QQ_RUN_ARGS
 
 
-def run_qq(config, job, qq_run_type, seed, mock_code, input_dir, output_dir):
+def run_qq(config, job, qq_run_type, cat_seed, qq_seed,
+           mock_code, input_dir, output_dir):
     """Create a QQ run and submit it
 
     Parameters
@@ -32,7 +33,8 @@ def run_qq(config, job, qq_run_type, seed, mock_code, input_dir, output_dir):
     seed_cat_path = None
     y1_flag = config.getboolean('y1_flag', False)
     if y1_flag:
-        job_id, seed_cat_path = create_qq_catalog(config, input_dir, job, qq_dir, seed, mock_code)
+        job_id, seed_cat_path = create_qq_catalog(
+            config, input_dir, job, qq_dir, cat_seed, mock_code)
 
     run_type = qq_run_type
     if config.getboolean('invert_cat_seed', False):
@@ -63,10 +65,10 @@ def run_qq(config, job, qq_run_type, seed, mock_code, input_dir, output_dir):
     if y1_flag:
         qq_args += f' --from-catalog {seed_cat_path}'
 
-    qq_args += f' --seed {seed}'
+    qq_args += f' --seed {qq_seed}'
     print(qq_args)
 
-    qq_script = create_qq_script(config, job, qq_dir, qq_args, seed, input_dir)
+    qq_script = create_qq_script(config, job, qq_dir, qq_args, qq_seed, input_dir)
 
     job_id = submit_utils.run_job(qq_script, dependency_ids=job_id,
                                   no_submit=job.getboolean('no_submit'))
@@ -74,13 +76,13 @@ def run_qq(config, job, qq_run_type, seed, mock_code, input_dir, output_dir):
     return job_id, dla_flag, bal_flag
 
 
-def create_qq_catalog(config, input_dir, job, qq_dir, seed, mock_code):
+def create_qq_catalog(config, input_dir, job, qq_dir, cat_seed, mock_code):
     submit_utils.set_umask()
 
     # Make the header
     time = submit_utils.convert_job_time(0.2)
     header = submit_utils.make_header(job.get('nersc_machine'), 'regular', 1, time=time,
-                                      omp_threads=128, job_name=f'qq_cat_{seed}',
+                                      omp_threads=128, job_name=f'qq_cat_{cat_seed}',
                                       err_file=qq_dir.run_dir/'run-%j.err',
                                       out_file=qq_dir.run_dir/'run-%j.out')
 
@@ -100,7 +102,7 @@ def create_qq_catalog(config, input_dir, job, qq_dir, seed, mock_code):
         raise ValueError(f'Unknown mock code {mock_code}')
 
     # text += '/global/cfs/cdirs/desicollab/users/acuceu/notebooks_perl/mocks/run_mocks/make_y1_cat.py'
-    text += f'gen_qso_catalog -i {master_cat_path} -o {seed_cat_path} --seed {seed}'
+    text += f'gen_qso_catalog -i {master_cat_path} -o {seed_cat_path} --seed {cat_seed}'
     if config.getboolean('invert_cat_seed', False):
         text += ' --invert'
     text += '\n\n'
@@ -118,7 +120,7 @@ def create_qq_catalog(config, input_dir, job, qq_dir, seed, mock_code):
     return job_id, seed_cat_path
 
 
-def create_qq_script(config, job, qq_dir, qq_args, seed, input_dir):
+def create_qq_script(config, job, qq_dir, qq_args, qq_seed, input_dir):
 
     submit_utils.set_umask()
 
@@ -137,7 +139,7 @@ def create_qq_script(config, job, qq_dir, qq_args, seed, input_dir):
     # Make the header
     time = submit_utils.convert_job_time(slurm_hours)
     header = submit_utils.make_header(job.get('nersc_machine'), slurm_queue, nodes, time=time,
-                                      omp_threads=nproc, job_name=f'qq_{seed}',
+                                      omp_threads=nproc, job_name=f'qq_{qq_seed}',
                                       err_file=qq_dir.run_dir/'run-%j.err',
                                       out_file=qq_dir.run_dir/'run-%j.out')
 

--- a/lyatools/quickquasars.py
+++ b/lyatools/quickquasars.py
@@ -36,14 +36,7 @@ def run_qq(config, job, qq_run_type, cat_seed, qq_seed,
         job_id, seed_cat_path = create_qq_catalog(
             config, input_dir, job, qq_dir, cat_seed, mock_code)
 
-    run_type = qq_run_type
-    if config.getboolean('invert_cat_seed', False):
-        run_type_list = qq_run_type.split('-')
-        if run_type_list[-1] != 'inverted':
-            raise ValueError('invert_cat_seed only works with inverted mocks.'
-                             'Append "inverted" to the qq run type to use it.')
-        run_type = '-'.join(run_type_list[:-1])
-    run_args = QQ_RUN_ARGS[run_type]
+    run_args = QQ_RUN_ARGS[qq_run_type]
 
     print('Found the following arguments to pass to quickquasars:')
     qq_args = ''

--- a/lyatools/run_mock.py
+++ b/lyatools/run_mock.py
@@ -175,6 +175,8 @@ class RunMocks:
 
             submit_utils.print_spacer_line()
 
+        print(export_dict['export_cov_commands'])
+
         global_struct, true_global_struct, raw_global_struct = self.get_global_struct()
 
         if self.export.getboolean('mpi_export_flag', False):

--- a/lyatools/run_mock.py
+++ b/lyatools/run_mock.py
@@ -132,7 +132,10 @@ class RunMocks:
                     seed, raw_analysis_struct, true_continuum=False, raw_analysis=True,
                     zcat_job_id=zcat_job_id, input_seed=input_seed
                 )
-                raw_exp_job_ids += [job_id]
+                if isinstance(job_id, list):
+                    raw_exp_job_ids += job_id
+                else:
+                    raw_exp_job_ids += [job_id]
                 for key, file in corr_files.items():
                     if key not in raw_corr_dict:
                         raw_corr_dict[key] = []
@@ -148,7 +151,10 @@ class RunMocks:
                     seed, true_analysis_struct, true_continuum=True, raw_analysis=False,
                     zcat_job_id=zcat_job_id
                 )
-                true_exp_job_ids += [job_id]
+                if isinstance(job_id, list):
+                    true_exp_job_ids += job_id
+                else:
+                    true_exp_job_ids += [job_id]
                 for key, file in corr_files.items():
                     if key not in true_corr_dict:
                         true_corr_dict[key] = []
@@ -164,7 +170,10 @@ class RunMocks:
                     seed, analysis_struct, true_continuum=False, raw_analysis=False,
                     zcat_job_id=zcat_job_id
                 )
-                exp_job_ids += [job_id]
+                if isinstance(job_id, list):
+                    exp_job_ids += job_id
+                else:
+                    exp_job_ids += [job_id]
                 for key, file in corr_files.items():
                     if key not in corr_dict:
                         corr_dict[key] = []

--- a/lyatools/run_mock.py
+++ b/lyatools/run_mock.py
@@ -38,6 +38,7 @@ class RunMocks:
         self.input_seeds = self.config['mock_setup'].get('input_seeds', None)
         self.cat_seeds = self.config['mock_setup'].get('cat_seeds', None)
         self.qq_seeds = self.config['mock_setup'].get('qq_seeds')
+        self.invert_cat_seed = self.qq.getboolean('invert_cat_seed', False)
 
         self.qq_run_type = self.config['mock_setup'].get('qq_run_type')
         self.run_type = self.config['mock_setup'].get('run_type')
@@ -94,11 +95,13 @@ class RunMocks:
 
         for input_seed, cat_seed, qq_seed in zip(input_seeds, cat_seeds, run_seeds):
             seed = f'{input_seed}.{cat_seed}.{qq_seed}'
+            if self.invert_cat_seed:
+                seed = f'{input_seed}.{cat_seed}i.{qq_seed}'
 
             # Run QQ
             zcat_job_id = None
             if self.run_qq_flag:
-                qq_job_id = self.run_qq(input_seed, cat_seed, qq_seed)
+                qq_job_id = self.run_qq(input_seed, cat_seed, qq_seed, seed)
                 submit_utils.print_spacer_line()
 
                 zcat_job_id = [self.run_zcat(seed, qq_job_id)]
@@ -236,10 +239,10 @@ class RunMocks:
 
         return corr_files, job_id
 
-    def run_qq(self, input_seed, cat_seed, qq_seed):
+    def run_qq(self, input_seed, cat_seed, qq_seed, seed):
         input_dir = Path(self.input_dir) / f'{self.mock_version}.{input_seed}'
-        output_dir = Path(self.qq_dir) / f'{self.mock_version}.{input_seed}.{cat_seed}.{qq_seed}'
-        print(f'Submitting QQ run for mock {self.mock_version}.{input_seed}.{cat_seed}.{qq_seed}')
+        output_dir = Path(self.qq_dir) / f'{self.mock_version}.{seed}'
+        print(f'Submitting QQ run for mock {self.mock_version}.{seed}')
 
         qq_job_id, self.dla_flag, self.bal_flag = run_qq(
             self.qq, self.job, self.qq_run_type, cat_seed, qq_seed,

--- a/lyatools/run_mock.py
+++ b/lyatools/run_mock.py
@@ -175,19 +175,19 @@ class RunMocks:
 
             submit_utils.print_spacer_line()
 
+        global_struct, true_global_struct, raw_global_struct = self.get_global_struct()
+
         if self.export.getboolean('mpi_export_flag', False):
             print('Starting MPI export job.')
             if self.run_raw_flag:
-                mpi_export(raw_export_dict, self.job, raw_analysis_struct, exp_job_ids)
+                mpi_export(raw_export_dict, self.job, raw_global_struct, exp_job_ids)
             if self.run_true_cont_flag:
-                mpi_export(true_export_dict, self.job, true_analysis_struct, true_exp_job_ids)
+                mpi_export(true_export_dict, self.job, true_global_struct, true_exp_job_ids)
             if not self.no_run_cont_fit_flag:
-                mpi_export(export_dict, self.job, analysis_struct, exp_job_ids)
+                mpi_export(export_dict, self.job, global_struct, exp_job_ids)
             submit_utils.print_spacer_line()
 
         if self.export.getboolean('stack_correlations'):
-            global_struct, true_global_struct, raw_global_struct = self.get_global_struct()
-
             add_dmat = self.export.getboolean('add_dmat')
             dmat_path = self.export.get('dmat_path')
             name_string = self.corr.get('name_string', None)

--- a/lyatools/run_mock.py
+++ b/lyatools/run_mock.py
@@ -180,7 +180,7 @@ class RunMocks:
         if self.export.getboolean('mpi_export_flag', False):
             print('Starting MPI export job.')
             if self.run_raw_flag:
-                mpi_export(raw_export_dict, self.job, raw_global_struct, exp_job_ids)
+                mpi_export(raw_export_dict, self.job, raw_global_struct, raw_exp_job_ids)
             if self.run_true_cont_flag:
                 mpi_export(true_export_dict, self.job, true_global_struct, true_exp_job_ids)
             if not self.no_run_cont_fit_flag:
@@ -254,6 +254,7 @@ class RunMocks:
         # Run export
         corr_files = {}
         job_id = None
+        export_commands, export_cov_commands = None, None
         if self.run_export_flag:
             print(f'Starting export jobs for seed {seed}.')
             corr_files, job_id, export_commands, export_cov_commands = self.run_export(
@@ -499,7 +500,18 @@ class RunMocks:
         job_id_cov, export_cov_commands = export_full_cov(
             seed, analysis_struct, corr_paths, self.job, self.export, corr_job_ids=corr_job_ids)
 
-        return corr_dict, [job_id, job_id_cov], export_commands, export_cov_commands
+        out_job_ids = []
+        if isinstance(job_id, list):
+            out_job_ids += job_id
+        else:
+            out_job_ids += [job_id]
+
+        if isinstance(job_id_cov, list):
+            out_job_ids += job_id_cov
+        else:
+            out_job_ids += [job_id_cov]
+
+        return corr_dict, out_job_ids, export_commands, export_cov_commands
 
     def input_dir_from_seed(self, input_seed):
         return Path(self.input_dir) / f'{self.mock_version}.{input_seed}'

--- a/lyatools/run_mock.py
+++ b/lyatools/run_mock.py
@@ -175,8 +175,6 @@ class RunMocks:
 
             submit_utils.print_spacer_line()
 
-        print(export_dict['export_cov_commands'])
-
         global_struct, true_global_struct, raw_global_struct = self.get_global_struct()
 
         if self.export.getboolean('mpi_export_flag', False):

--- a/lyatools/run_mock.py
+++ b/lyatools/run_mock.py
@@ -7,7 +7,7 @@ from lyatools.quickquasars import run_qq
 from lyatools.delta_extraction import make_delta_runs
 from lyatools.qsonic import make_qsonic_runs
 from lyatools.correlations import make_correlation_runs
-from lyatools.export import make_export_runs, stack_correlations
+from lyatools.export import make_export_runs, stack_correlations, export_full_cov
 
 
 class RunMocks:
@@ -473,7 +473,10 @@ class RunMocks:
         corr_dict, job_id = make_export_runs(
             seed, analysis_struct, corr_paths, self.job, self.export, corr_job_ids=corr_job_ids)
 
-        return corr_dict, job_id
+        job_id_cov = export_full_cov(
+            seed, analysis_struct, corr_paths, self.job, corr_job_ids=corr_job_ids)
+
+        return corr_dict, [job_id, job_id_cov]
 
     def input_dir_from_seed(self, input_seed):
         return Path(self.input_dir) / f'{self.mock_version}.{input_seed}'

--- a/lyatools/run_mock.py
+++ b/lyatools/run_mock.py
@@ -470,11 +470,8 @@ class RunMocks:
                              'In the [control] section set "run_corr" to True. '
                              'Correlations are *not* recomputed if they already exist.')
 
-        corr_dict, job_id = make_export_runs(seed, analysis_struct, corr_paths, self.job,
-                                             add_dmat=self.export.getboolean('add_dmat'),
-                                             dmat_path=self.export.get('dmat_path'),
-                                             shuffled=self.export.getboolean('subtract_shuffled'),
-                                             corr_job_ids=corr_job_ids)
+        corr_dict, job_id = make_export_runs(
+            seed, analysis_struct, corr_paths, self.job, self.export, corr_job_ids=corr_job_ids)
 
         return corr_dict, job_id
 

--- a/lyatools/scripts/mpi_export.py
+++ b/lyatools/scripts/mpi_export.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+import sys
+import argparse
+from mpi4py import MPI
+from subprocess import run
+
+from lyatools import submit_utils
+
+
+def main():
+    submit_utils.set_umask()
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("-i", "--commands", type=str, required=True, nargs='*',
+                        help="The picca export commands to run.")
+    parser.add_argument("-l", "--log-path", type=str, required=True,
+                        help="The path to the log files.")
+
+    args = parser.parse_args()
+
+    def print_func(message):
+        print(f'Rank {cpu_rank}: {message}')
+        sys.stdout.flush()
+
+    mpi_comm = MPI.COMM_WORLD
+    cpu_rank = mpi_comm.Get_rank()
+    num_cpus = mpi_comm.Get_size()
+
+    num_tasks_per_proc = len(args.commands) // num_cpus
+    remainder = len(args.commands) % num_cpus
+    if cpu_rank < remainder:
+        start = int(cpu_rank * (num_tasks_per_proc + 1))
+        stop = int(start + num_tasks_per_proc + 1)
+    else:
+        start = int(cpu_rank * num_tasks_per_proc + remainder)
+        stop = int(start + num_tasks_per_proc)
+
+    print_func(f'Running export indexes {start} to {stop}.')
+
+    for i in range(start, stop):
+        print_func(f'Running command: {args.commands[i]}')
+        process = run(args.commands[i], shell=True, capture_output=True)
+        if process.returncode != 0:
+            raise ValueError(f'Running {args.commands[i]} returned non-zero exitcode '
+                             f'with error {process.stderr}')
+
+        with open(f'{args.log_path}/export_{i}.log', 'w') as f:
+            f.write(process.stdout.decode('utf-8'))
+        print_func(f'Finished export index {i}.')
+
+
+if __name__ == '__main__':
+    main()

--- a/lyatools/scripts/run_vega_fitter.py
+++ b/lyatools/scripts/run_vega_fitter.py
@@ -43,6 +43,7 @@ def main():
     input_seeds = config['mock_setup'].get('input_seeds', None)
     cat_seeds = config['mock_setup'].get('cat_seeds', None)
     qq_seeds = config['mock_setup'].get('qq_seeds')
+    inverted_cat_seed = config['mock_setup'].getboolean('inverted_cat_seed', False)
 
     if input_seeds is None:
         input_seeds = qq_seeds
@@ -70,7 +71,11 @@ def main():
     print_func(f'Rank {cpu_rank} running seeds {start} to {stop}.')
 
     for i in range(start, stop):
-        version = f'{mock_version}.{input_seeds[i]}.{cat_seeds[i]}.{seeds[i]}'
+        if inverted_cat_seed:
+            version = f'{mock_version}.{input_seeds[i]}.{cat_seeds[i]}i.{seeds[i]}'
+        else:
+            version = f'{mock_version}.{input_seeds[i]}.{cat_seeds[i]}.{seeds[i]}'
+
         if name_extension is not None:
             config['fit_info']['name_extension'] = f'{name_extension}_{version}'
         else:

--- a/lyatools/scripts/run_vega_fitter.py
+++ b/lyatools/scripts/run_vega_fitter.py
@@ -54,7 +54,14 @@ def main():
     print_func(f'Rank {cpu_rank} running seeds {start} to {stop}.')
 
     for seed in seeds[start:stop]:
-        corr_path = analysis_dir / f'{mock_version}.{seed}' / f'{qq_run_type}'
+        version = f'{mock_version}.{seed}'
+        name_extension = config['fit_info'].get('name_extension', None)
+        if name_extension is not None:
+            config['fit_info']['name_extension'] = f'{name_extension}_{version}'
+        else:
+            config['fit_info']['name_extension'] = f'{version}'
+
+        corr_path = analysis_dir / f'{version}' / f'{qq_run_type}'
         corr_path = corr_path / f'{analysis_name}' / 'correlations'
 
         run_vega_fitter(config, corr_path, output_dir, run_flag=run_flag)

--- a/lyatools/scripts/run_vega_fitter.py
+++ b/lyatools/scripts/run_vega_fitter.py
@@ -24,10 +24,8 @@ def main():
     num_cpus = mpi_comm.Get_size()
 
     def print_func(message):
-        if cpu_rank == 0:
-            print(message)
+        print(f'Rank {cpu_rank}: {message}')
         sys.stdout.flush()
-        mpi_comm.barrier()
 
     config = configparser.ConfigParser()
     config.read(args.config_file)
@@ -68,7 +66,7 @@ def main():
         start = int(cpu_rank * num_tasks_per_proc + remainder)
         stop = int(start + num_tasks_per_proc)
 
-    print_func(f'Rank {cpu_rank} running seeds {start} to {stop}.')
+    print_func(f'Running seeds {start} to {stop}.')
 
     for i in range(start, stop):
         if inverted_cat_seed:
@@ -85,6 +83,7 @@ def main():
         corr_path = corr_path / f'{analysis_name}' / 'correlations'
 
         run_vega_fitter(config, corr_path, output_dir, run_flag=run_flag)
+        print_func(f'Finished seed {seeds[i]}.')
 
 
 if __name__ == '__main__':

--- a/lyatools/scripts/run_vega_fitter.py
+++ b/lyatools/scripts/run_vega_fitter.py
@@ -28,6 +28,7 @@ def main():
         sys.stdout.flush()
 
     config = configparser.ConfigParser()
+    config.optionxform = lambda option: option
     config.read(args.config_file)
 
     analysis_dir = Path(config['mock_setup'].get('analysis_dir'))

--- a/lyatools/scripts/run_vega_fitter.py
+++ b/lyatools/scripts/run_vega_fitter.py
@@ -34,13 +34,29 @@ def main():
 
     analysis_dir = Path(config['mock_setup'].get('analysis_dir'))
     mock_version = config['mock_setup'].get('mock_version')
-    qq_seeds = config['mock_setup'].get('qq_seeds')
     qq_run_type = config['mock_setup'].get('qq_run_type')
     analysis_name = config['mock_setup'].get('analysis_name', 'baseline')
     output_dir = config['mock_setup'].get('output_dir')
     run_flag = config['mock_setup'].getboolean('run_flag', True)
+    name_extension = config['fit_info'].get('name_extension', None)
+
+    input_seeds = config['mock_setup'].get('input_seeds', None)
+    cat_seeds = config['mock_setup'].get('cat_seeds', None)
+    qq_seeds = config['mock_setup'].get('qq_seeds')
+
+    if input_seeds is None:
+        input_seeds = qq_seeds
+    if cat_seeds is None:
+        cat_seeds = qq_seeds
 
     seeds = np.array(submit_utils.get_seed_list(qq_seeds))
+    input_seeds = submit_utils.get_seed_list(input_seeds)
+    cat_seeds = submit_utils.get_seed_list(cat_seeds)
+
+    if len(input_seeds) != len(seeds):
+        raise ValueError('Number of input seeds and qq seeds must match.')
+    if len(cat_seeds) != len(seeds):
+        raise ValueError('Number of catalog seeds and qq seeds must match.')
 
     num_tasks_per_proc = len(seeds) // num_cpus
     remainder = len(seeds) % num_cpus
@@ -53,9 +69,8 @@ def main():
 
     print_func(f'Rank {cpu_rank} running seeds {start} to {stop}.')
 
-    for seed in seeds[start:stop]:
-        version = f'{mock_version}.{seed}'
-        name_extension = config['fit_info'].get('name_extension', None)
+    for i in range(start, stop):
+        version = f'{mock_version}.{input_seeds[i]}.{cat_seeds[i]}.{seeds[i]}'
         if name_extension is not None:
             config['fit_info']['name_extension'] = f'{name_extension}_{version}'
         else:

--- a/lyatools/scripts/run_vega_fitter.py
+++ b/lyatools/scripts/run_vega_fitter.py
@@ -38,6 +38,7 @@ def main():
     output_dir = config['mock_setup'].get('output_dir')
     run_flag = config['mock_setup'].getboolean('run_flag', True)
     name_extension = config['fit_info'].get('name_extension', None)
+    cat_path = config['mock_setup'].get('cat_path', None)
 
     input_seeds = config['mock_setup'].get('input_seeds', None)
     cat_seeds = config['mock_setup'].get('cat_seeds', None)
@@ -80,10 +81,13 @@ def main():
         else:
             config['fit_info']['name_extension'] = f'{version}'
 
-        corr_path = analysis_dir / f'{version}' / f'{qq_run_type}'
-        corr_path = corr_path / f'{analysis_name}' / 'correlations'
+        corr_path = analysis_dir / version / qq_run_type
+        corr_path = corr_path / analysis_name / 'correlations'
 
-        run_vega_fitter(config, corr_path, output_dir, run_flag=run_flag)
+        if cat_path is not None:
+            cat_path = Path(cat_path) / version / qq_run_type / 'zcat_gauss_400.fits'
+
+        run_vega_fitter(config, corr_path, output_dir, cat_path, run_flag=run_flag)
         print_func(f'Finished seed {seeds[i]}.')
 
 

--- a/lyatools/scripts/run_vega_fitter.py
+++ b/lyatools/scripts/run_vega_fitter.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+import sys
+import argparse
+import numpy as np
+import configparser
+from mpi4py import MPI
+from pathlib import Path
+
+from lyatools import submit_utils
+from lyatools.vegafit import run_vega_fitter
+
+
+def main():
+    submit_utils.set_umask()
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("-i", "--config-file", type=str, required=True,
+                        help="The path to the lyatools-vega configuration file.")
+
+    args = parser.parse_args()
+
+    mpi_comm = MPI.COMM_WORLD
+    cpu_rank = mpi_comm.Get_rank()
+    num_cpus = mpi_comm.Get_size()
+
+    def print_func(message):
+        if cpu_rank == 0:
+            print(message)
+        sys.stdout.flush()
+        mpi_comm.barrier()
+
+    config = configparser.ConfigParser()
+    config.read(args.config_file)
+
+    analysis_dir = Path(config['mock_setup'].get('analysis_dir'))
+    mock_version = config['mock_setup'].get('mock_version')
+    qq_seeds = config['mock_setup'].get('qq_seeds')
+    qq_run_type = config['mock_setup'].get('qq_run_type')
+    analysis_name = config['mock_setup'].get('analysis_name', 'baseline')
+    output_dir = config['mock_setup'].get('output_dir')
+    run_flag = config['mock_setup'].getboolean('run_flag', True)
+
+    seeds = np.array(submit_utils.get_seed_list(qq_seeds))
+
+    num_tasks_per_proc = len(seeds) // num_cpus
+    remainder = len(seeds) % num_cpus
+    if cpu_rank < remainder:
+        start = int(cpu_rank * (num_tasks_per_proc + 1))
+        stop = int(start + num_tasks_per_proc + 1)
+    else:
+        start = int(cpu_rank * num_tasks_per_proc + remainder)
+        stop = int(start + num_tasks_per_proc)
+
+    print_func(f'Rank {cpu_rank} running seeds {start} to {stop}.')
+
+    for seed in seeds[start:stop]:
+        corr_path = analysis_dir / f'{mock_version}.{seed}' / f'{qq_run_type}'
+        corr_path = corr_path / f'{analysis_name}' / 'correlations'
+
+        run_vega_fitter(config, corr_path, output_dir, run_flag=run_flag)
+
+
+if __name__ == '__main__':
+    main()

--- a/lyatools/scripts/stack_export.py
+++ b/lyatools/scripts/stack_export.py
@@ -15,6 +15,9 @@ def main():
 
     parser.add_argument("--out", type=str, required=True, help="name of output file")
 
+    parser.add_argument("--no-smooth-cov", action="store_true", default=False,
+                        help="Whether to turn off smoothing of the covariance matrix")
+
     parser.add_argument('--dmat', type=str, default=None, required=False,
                         help=('Distortion matrix produced via picca_dmat.py, picca_xdmat.py... '
                               '(if not provided will be identity)'))
@@ -24,7 +27,8 @@ def main():
 
     args = parser.parse_args()
 
-    stack_export_correlations(args.data, args.out, args.dmat, args.shuffled_correlations)
+    stack_export_correlations(
+        args.data, args.out, not args.no_smooth_cov, args.dmat, args.shuffled_correlations)
 
 
 if __name__ == '__main__':

--- a/lyatools/stack.py
+++ b/lyatools/stack.py
@@ -1,7 +1,7 @@
 import fitsio
 import numpy as np
 import scipy.linalg
-from picca.utils import smooth_cov
+from picca.utils import smooth_cov, compute_cov
 
 
 def get_shuffled_correlations(files, headers_to_check_match_values):
@@ -24,7 +24,8 @@ def get_shuffled_correlations(files, headers_to_check_match_values):
     return xi_shuffled[:, None]
 
 
-def stack_export_correlations(input_files, output_file, dmat_path=None, shuffled_correlations=None):
+def stack_export_correlations(
+        input_files, output_file, smooth_cov_flag=True, dmat_path=None, shuffled_correlations=None):
     """Stacks correlation functions measured in different mocks.
     Parameters
     ----------
@@ -116,9 +117,12 @@ def stack_export_correlations(input_files, output_file, dmat_path=None, shuffled
     delta_r_par = (r_par_max - r_par_min) / headers_to_check_match_values['NP']
     delta_r_trans = (r_trans_max - 0.) / headers_to_check_match_values['NT']
 
-    print("INFO: The covariance will be smoothed")
-    covariance = smooth_cov(xi, weights, r_par, r_trans, delta_r_trans=delta_r_trans,
-                            delta_r_par=delta_r_par)
+    if smooth_cov_flag:
+        print("INFO: The covariance will be smoothed")
+        covariance = smooth_cov(
+            xi, weights, r_par, r_trans, delta_r_trans=delta_r_trans, delta_r_par=delta_r_par)
+    else:
+        covariance = compute_cov(xi, weights)
 
     xi = (xi * weights).sum(axis=0)
     weights = weights.sum(axis=0)

--- a/lyatools/vegafit.py
+++ b/lyatools/vegafit.py
@@ -1,0 +1,132 @@
+from vega import BuildConfig, FitResults, run_vega
+
+
+def get_correlations_dict(corr_config, corr_path):
+    correlations = {'lyaxlya': {}, 'lyaxqso': {}, 'lyaxlyb': {}, 'lybxqso': {}}
+
+    dist_path = corr_config['dist_path']
+    rmin = corr_config.getfloat('rmin', 10.)
+    rmax = corr_config.getfloat('rmax', 180.)
+    fast_metals = corr_config.getboolean('fast_metals', True)
+
+    correlations['lyaxlya']['corr_path'] = f"{corr_path / 'cf_lya_lya_0_10-exp.fits.gz'}"
+    correlations['lyaxlya']['distortion-file'] = f"{dist_path / 'dmat_lya_lya_0_10.fits.gz'}"
+    correlations['lyaxlya']['metal_path'] = f"{dist_path / 'metal_dmat_lya_lya_0_10.fits.gz'}"
+    correlations['lyaxlya']['r-min'] = rmin
+    correlations['lyaxlya']['r-max'] = rmax
+    correlations['lyaxlya']['fast_metals'] = f'{fast_metals}'
+
+    correlations['lyaxlyb']['corr_path'] = f"{corr_path / 'cf_lya_lyb_0_10-exp.fits.gz'}"
+    correlations['lyaxlyb']['distortion-file'] = f"{dist_path / 'dmat_lya_lyb_0_10.fits.gz'}"
+    correlations['lyaxlyb']['metal_path'] = f"{dist_path / 'metal_dmat_lya_lyb_0_10.fits.gz'}"
+    correlations['lyaxlyb']['r-min'] = rmin
+    correlations['lyaxlyb']['r-max'] = rmax
+    correlations['lyaxlyb']['fast_metals'] = f'{fast_metals}'
+
+    correlations['lyaxqso']['corr_path'] = f"{corr_path / 'xcf_lya_qso_0_10-exp.fits.gz'}"
+    correlations['lyaxqso']['distortion-file'] = f"{dist_path / 'xdmat_lya_qso_0_10.fits.gz'}"
+    correlations['lyaxqso']['metal_path'] = f"{dist_path / 'metal_xdmat_lya_qso_0_10.fits.gz'}"
+    correlations['lyaxqso']['r-min'] = rmin
+    correlations['lyaxqso']['r-max'] = rmax
+    correlations['lyaxqso']['fast_metals'] = f'{fast_metals}'
+
+    correlations['lybxqso']['corr_path'] = f"{corr_path / 'xcf_lyb_qso_0_10-exp.fits.gz'}"
+    correlations['lybxqso']['distortion-file'] = f"{dist_path / 'xdmat_lyb_qso_0_10.fits.gz'}"
+    correlations['lybxqso']['metal_path'] = f"{dist_path / 'metal_xdmat_lyb_qso_0_10.fits.gz'}"
+    correlations['lybxqso']['r-min'] = rmin
+    correlations['lybxqso']['r-max'] = rmax
+    correlations['lybxqso']['fast_metals'] = f'{fast_metals}'
+
+    return correlations
+
+
+def get_builder(builder_config=None):
+    options = {
+        'scale_params': 'ap_at', 'template': 'PlanckDR12/PlanckDR12.fits',
+        'full_shape': False, 'smooth_scaling': False,
+        'small_scale_nl': False, 'bao_broadening': False, 'use_metal_autos': True,
+        'fullshape_smoothing': 'gauss', 'fullshape_smoothing_metals': True,
+        'velocity_dispersion': 'gauss', 'hcd_model': 'Rogers2018',
+        'metals': ['SiII(1260)', 'SiIII(1207)', 'SiII(1193)', 'SiII(1190)']
+    }
+
+    if builder_config is None:
+        return BuildConfig(options, overwrite=True)
+
+    for key in builder_config:
+        if key == 'metals':
+            options[key] = builder_config[key].split(' ')
+        if key in options:
+            options[key] = builder_config[key]
+
+    return BuildConfig(options, overwrite=True)
+
+
+def get_fit_info(fit_info_config=None):
+    fit_info = {
+        'fitter': True, 'sampler': True, 'zeff': None, 'zeff_rmin': -300., 'zeff_rmax': 300.,
+        'bias_beta_config': {'LYA': 'bias_beta', 'QSO': 'bias_bias_eta'},
+        'Polychord': {'num_live': '192', 'boost_posterior': '0'},
+        'priors': {'beta_hcd': 'gaussian 0.5 0.09'}
+    }
+
+    if fit_info_config is None:
+        return fit_info
+
+    for key in fit_info_config:
+        if 'bias_beta_config' in key:
+            _, key2 = key.split('.')
+            fit_info['bias_beta_config'][key2] = fit_info_config[key]
+
+        elif 'Polychord' in key:
+            _, key2 = key.split('.')
+            fit_info['Polychord'][key2] = fit_info_config[key]
+
+        elif 'priors' in key:
+            if key == 'priors.None':
+                fit_info['priors'] = {}
+            else:
+                _, key2 = key.split('.')
+                fit_info['priors'][key2] = fit_info_config[key]
+
+        elif key in fit_info:
+            fit_info[key] = fit_info_config[key]
+
+        else:
+            raise ValueError(f'Key {key} not recognized.')
+
+    return fit_info
+
+
+def build_config(config, corr_path, out_path):
+    correlations = get_correlations_dict(corr_path, config['correlations'])
+    config_builder = get_builder(config['builder'])
+    fit_info = get_fit_info(config['fit_info'])
+
+    fit_type = config['fit_info']['fit_type']
+    name_extension = config['fit_info']['name_extension']
+
+    fit_info['sample_params'] = config['fit_info']['sample_params']
+
+    parameters = {}
+    for key in config['parameters']:
+        parameters[key] = config['parameters'][key]
+
+    vega_res_path = config['fit_info'].get('match_params', None)
+    if vega_res_path is not None:
+        res = FitResults(vega_res_path)
+        parameters = parameters | res.params
+
+    main_path = config_builder.build(
+        correlations, fit_type, fit_info, out_path,
+        parameters=parameters, name_extension=name_extension
+    )
+
+    return main_path
+
+
+def run_vega_fitter(config, corr_path, out_path, run_flag=True):
+    main_path = build_config(config, corr_path, out_path)
+
+    if run_flag:
+        run_vega(main_path)

--- a/lyatools/vegafit.py
+++ b/lyatools/vegafit.py
@@ -96,9 +96,6 @@ def get_fit_info(fit_info_config=None):
         elif key in fit_info:
             fit_info[key] = fit_info_config[key]
 
-        else:
-            raise ValueError(f'Key {key} not recognized.')
-
     return fit_info
 
 

--- a/lyatools/vegafit.py
+++ b/lyatools/vegafit.py
@@ -76,11 +76,12 @@ def get_fit_info(fit_info_config=None):
         'Polychord': {'num_live': '192', 'boost_posterior': '0'},
         'priors': {'beta_hcd': 'gaussian 0.5 0.09'}
     }
-
+    print(fit_info_config)
     if fit_info_config is None:
         return fit_info
 
     for key in fit_info_config:
+        print(key)
         if 'bias_beta_config' in key:
             _, key2 = key.split('.')
             fit_info['bias_beta_config'][key2] = fit_info_config[key]
@@ -88,9 +89,10 @@ def get_fit_info(fit_info_config=None):
         elif 'Polychord' in key:
             _, key2 = key.split('.')
             fit_info['Polychord'][key2] = fit_info_config[key]
-
         elif 'priors' in key:
+            print(key)
             if key == 'priors.None':
+                print(key)
                 fit_info['priors'] = {}
             else:
                 _, key2 = key.split('.')

--- a/lyatools/vegafit.py
+++ b/lyatools/vegafit.py
@@ -1,10 +1,14 @@
+from pathlib import Path
 from vega import BuildConfig, FitResults, run_vega
 
 
 def get_correlations_dict(corr_config, corr_path):
     correlations = {'lyaxlya': {}, 'lyaxqso': {}, 'lyaxlyb': {}, 'lybxqso': {}}
 
-    dist_path = corr_config['dist_path']
+    dist_path = Path(corr_config['dist_path'])
+    if not dist_path.exists():
+        raise ValueError(f'Distortion path does not exist: {dist_path}')
+
     rmin = corr_config.getfloat('rmin', 10.)
     rmax = corr_config.getfloat('rmax', 180.)
     fast_metals = corr_config.getboolean('fast_metals', True)

--- a/lyatools/vegafit.py
+++ b/lyatools/vegafit.py
@@ -58,10 +58,13 @@ def get_builder(builder_config=None):
         return BuildConfig(options, overwrite=True)
 
     for key in builder_config:
-        if key == 'metals':
-            options[key] = builder_config[key].split(' ')
-        if key in options:
-            options[key] = builder_config[key]
+        if builder_config[key] == 'None' and key in options:
+            del options[key]
+        else:
+            if key == 'metals':
+                options[key] = builder_config[key].split(' ')
+            if key in options:
+                options[key] = builder_config[key]
 
     return BuildConfig(options, overwrite=True)
 

--- a/lyatools/vegafit.py
+++ b/lyatools/vegafit.py
@@ -76,12 +76,11 @@ def get_fit_info(fit_info_config=None):
         'Polychord': {'num_live': '192', 'boost_posterior': '0'},
         'priors': {'beta_hcd': 'gaussian 0.5 0.09'}
     }
-    print(fit_info_config)
+
     if fit_info_config is None:
         return fit_info
 
     for key in fit_info_config:
-        print(key)
         if 'bias_beta_config' in key:
             _, key2 = key.split('.')
             fit_info['bias_beta_config'][key2] = fit_info_config[key]
@@ -90,9 +89,7 @@ def get_fit_info(fit_info_config=None):
             _, key2 = key.split('.')
             fit_info['Polychord'][key2] = fit_info_config[key]
         elif 'priors' in key:
-            print(key)
             if key == 'priors.None':
-                print(key)
                 fit_info['priors'] = {}
             else:
                 _, key2 = key.split('.')

--- a/lyatools/vegafit.py
+++ b/lyatools/vegafit.py
@@ -103,7 +103,7 @@ def get_fit_info(fit_info_config=None):
 
 
 def build_config(config, corr_path, out_path):
-    correlations = get_correlations_dict(corr_path, config['correlations'])
+    correlations = get_correlations_dict(config['correlations'], corr_path)
     config_builder = get_builder(config['builder'])
     fit_info = get_fit_info(config['fit_info'])
 

--- a/lyatools/vegafit.py
+++ b/lyatools/vegafit.py
@@ -98,6 +98,9 @@ def get_fit_info(fit_info_config=None):
         elif key in fit_info:
             fit_info[key] = fit_info_config[key]
 
+        if key == 'global_cov_file':
+            fit_info['global_cov_file'] = fit_info_config[key]
+
     return fit_info
 
 

--- a/lyatools/vegafit.py
+++ b/lyatools/vegafit.py
@@ -107,7 +107,7 @@ def build_config(config, corr_path, out_path):
     fit_type = config['fit_info']['fit_type']
     name_extension = config['fit_info']['name_extension']
 
-    fit_info['sample_params'] = config['fit_info']['sample_params']
+    fit_info['sample_params'] = config['fit_info']['sample_params'].split(' ')
 
     parameters = {}
     for key in config['parameters']:

--- a/lyatools/vegafit.py
+++ b/lyatools/vegafit.py
@@ -129,7 +129,7 @@ def build_config(config, corr_path, out_path, cat_path=None):
 
     use_full_cov = config['fit_info'].getboolean('use_full_cov', True)
     if use_full_cov and 'global_cov_file' not in fit_info:
-        fit_info['global_cov_file'] = corr_path / 'full_cov_smooth.fits'
+        fit_info['global_cov_file'] = str(corr_path / 'full_cov_smooth.fits')
 
     fit_info['sample_params'] = config['fit_info']['sample_params'].split(' ')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 scipy
 fitsio
 picca
+vega

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ console_scripts =
 	lyatools-make-bal-cat = lyatools.scripts.make_bal_cat:main
 	lyatools-add-zerr = lyatools.scripts.add_zerr:main
 	lyatools-run-vega = lyatools.scripts.run_vega_fitter:main
+	lyatools-mpi-export = lyatools.scripts.mpi_export:main
 
 [options.extras_require]
 dev = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ console_scripts =
 	lyatools-make-dla-cat = lyatools.scripts.make_dla_cat:main
 	lyatools-make-bal-cat = lyatools.scripts.make_bal_cat:main
 	lyatools-add-zerr = lyatools.scripts.add_zerr:main
+	lyatools-run-vega = lyatools.scripts.run_vega_fitter:main
 
 [options.extras_require]
 dev = 


### PR DESCRIPTION
This PR addresses Issue #1.

There are now three different seeds used to identify a mock:
- input_seed: Identifies the input transmission box used
- cat_seed: The seed used to generate the QSO catalog from the input master catalog
- qq_seed: The seed used to generate the fake spectra through QQ

The first two are optional, and if not passed, the usual qq_seed will be used. This means all directory names from now on will be of the form:
`v{x}.{y}.{input_seed}.{cat_seed}.{qq_seed}`,
where `v{x}.{y}` is the original raw mock version (currently v9.0 for LyaColore, and v4.7 for Saclay).

Furthermore, there is a new `invert_cat_seed` option. When this is activated, all random numbers produced at the catalog generation step are inverted in order to produce an independent QSO catalog from the same box using the same footprint. These mocks will have an `i` appended to their `cat_seed` to differentiate them from the normal mocks. So for these mocks, directories will be of the form:
`v{x}.{y}.{input_seed}.{cat_seed}i.{qq_seed}`.

For more details on the setup see: https://github.com/andreicuceu/lyatools/blob/more-seeds/examples/desi_y5.ini