### PR TITLE
Fix raw_deltas computation for Saclay mocks

### DIFF
--- a/lyatools/raw_deltas.py
+++ b/lyatools/raw_deltas.py
@@ -1,9 +1,10 @@
 from . import submit_utils, dir_handlers
 
 LYA_TRANSMISSION_HDUNAME = {
-    'lyacolore':'F_LYA',
+    'lyacolore': 'F_LYA',
     'saclay': 'TRANSMISSION'
 }
+
 
 def make_raw_deltas(qso_cat, skewers_path, analysis_tree, config, mock_type, job, qq_job_id=None):
     job_ids = []

--- a/lyatools/raw_deltas.py
+++ b/lyatools/raw_deltas.py
@@ -1,11 +1,15 @@
 from . import submit_utils, dir_handlers
 
+LYA_TRANSMISSION_HDUNAME = {
+    'lyacolore':'F_LYA',
+    'saclay': 'TRANSMISSION'
+}
 
-def make_raw_deltas(qso_cat, skewers_path, analysis_tree, config, job, qq_job_id=None):
+def make_raw_deltas(qso_cat, skewers_path, analysis_tree, config, mock_type, job, qq_job_id=None):
     job_ids = []
     if config.getboolean('run_lya_region'):
         id = run_raw_deltas(
-            qso_cat, skewers_path, analysis_tree, config, job,
+            qso_cat, skewers_path, analysis_tree, config, mock_type, job,
             qq_job_id=qq_job_id, region_name='lya',
             lambda_rest_min=config.getfloat('lambda_rest_lya_min'),
             lambda_rest_max=config.getfloat('lambda_rest_lya_max'),
@@ -14,7 +18,7 @@ def make_raw_deltas(qso_cat, skewers_path, analysis_tree, config, job, qq_job_id
 
     if config.getboolean('run_lyb_region'):
         id = run_raw_deltas(
-            qso_cat, skewers_path, analysis_tree, config, job,
+            qso_cat, skewers_path, analysis_tree, config, mock_type, job,
             qq_job_id=qq_job_id, region_name='lyb',
             lambda_rest_min=config.getfloat('lambda_rest_lyb_min'),
             lambda_rest_max=config.getfloat('lambda_rest_lyb_max'),
@@ -28,7 +32,7 @@ def make_raw_deltas(qso_cat, skewers_path, analysis_tree, config, job, qq_job_id
 
 
 def run_raw_deltas(
-        qso_cat, skewers_path, analysis_tree, config, job, qq_job_id=None,
+        qso_cat, skewers_path, analysis_tree, config, mock_type, job, qq_job_id=None,
         region_name='lya', lambda_rest_min=1040, lambda_rest_max=1200,
 ):
     if region_name == 'lya':
@@ -60,6 +64,7 @@ def run_raw_deltas(
     text += f'lambda_min_rest_frame={lambda_rest_min}, '
     text += f'lambda_max_rest_frame={lambda_rest_max}, '
     text += f'delta_lambda={delta_lambda}, lin_spaced=True, nproc={nproc}, use_splines=True, '
+    text += f'tracer="{LYA_TRANSMISSION_HDUNAME[mock_type]}", '
 
     if (max_num_spec is not None) and (max_num_spec > 0):
         text += f'max_num_spec={max_num_spec},  '

--- a/lyatools/run_one_mock.py
+++ b/lyatools/run_one_mock.py
@@ -239,7 +239,7 @@ class MockRun:
                 skewers_path = self.qq_tree.skewers_path
 
             job_id = make_raw_deltas(
-                qso_cat, skewers_path, self.analysis_tree, self.deltas_config,
+                qso_cat, skewers_path, self.analysis_tree, self.deltas_config, self.mock_type,
                 self.job_config, qq_job_id=qq_job_id
             )
             return job_id


### PR DESCRIPTION
Small modifications to lyatools/raw_deltas.py allowing to change the transmissions HDU name for the raw_deltas analysis.

The previous behavior enforced `tracer='F_LYA'` in the raw_deltas script. This only works for lyacolore mocks. Saclay mocks use 'TRANSMISSION' for their naming.  I made it flexible to modify this (if required) with a simple defaults dictionary at the beginning of the `raw_deltas.py` script.

With this modifications I was able to generate a raw analysis for one LyaColore and one Saclay mock realizations. And should work for massive production too. 

This PR requires the approval of https://github.com/igmhub/picca/pull/1088, that allows raw_deltas to read the current mock redshift catalog format, before starting the massive production of raw analyses.  